### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <groupId>net.okocraft.ttt</groupId>
     <artifactId>TTT</artifactId>
     <version>1.0.0-SNAPSHOT</version>
@@ -23,7 +23,7 @@
             <url>https://maven.enginehub.org/repo/</url>
         </repository>
     </repositories>
-    
+
     <dependencies>
         <dependency>
             <groupId>io.papermc.paper</groupId>
@@ -126,6 +126,26 @@
                         <relocation>
                             <pattern>com.github.siroshun09</pattern>
                             <shadedPattern>${project.groupId}.lib</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>club.minnced</pattern>
+                            <shadedPattern>${project.groupId}.lib</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.zaxxer</pattern>
+                            <shadedPattern>${project.groupId}.lib</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>okio</pattern>
+                            <shadedPattern>${project.groupId}.lib.okio</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>okhttp3</pattern>
+                            <shadedPattern>${project.groupId}.lib.okhttp3</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.json</pattern>
+                            <shadedPattern>${project.groupId}.lib.json</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,6 @@
             <id>sk89q-repo</id>
             <url>https://maven.enginehub.org/repo/</url>
         </repository>
-        <repository>
-            <id>intellectualsites-repo</id>
-            <url>https://mvn.intellectualsites.com/content/groups/public/</url>
-        </repository>
     </repositories>
     
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,14 @@
         <dependency>
             <groupId>com.plotsquared</groupId>
             <artifactId>PlotSquared-Bukkit</artifactId>
-            <version>6.2.1</version>
+            <version>6.4.0</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.EngineHub</groupId>
+                    <artifactId>SquirrelID</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.siroshun09.configapi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.0.0</version>
+            <version>5.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Updated

- HikariCP 5.0.1
- PlotSquared-Bukkit 6.4.0

## Other

- Remove intellectualsites-repo because it is closed (moved to maven central)
- Relocate dependencies without slf4j
  - slf4j だけは再配置したら問題が起きた記憶があるのでそのままにしています